### PR TITLE
Refactor: 플레이페이지 전환 시 스크롤 나타나던 현상

### DIFF
--- a/frontend/static/css/play.css
+++ b/frontend/static/css/play.css
@@ -46,7 +46,7 @@
 
 @keyframes slideInFromRight {
   0% {
-    transform: translateX(100%);
+    transform: translateX(-50%);
     opacity: 0;
   }
   100% {
@@ -57,7 +57,7 @@
 
 .play_nav {
   animation: slideInFromRight 0.8s ease-in-out;
-  transition: background-color 0.3s ease-in-out;
+  will-change: transform, opacity;
 }
 
 .local_modal_heading {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16

## 📝작업 내용

> 플레이페이지로 전환시에 밑에 스크롤바가 나타나던 현상을 수정했습니다.
nav_bar들이 오른쪽에서 왼쪽으로 이동하는 애니메이션을 넣었는데, 해당부분이 커서 스크롤바가 잠시 나타났었습니다.
왼쪽에서 이동하는 애니메이션으로 수정해서 고쳤습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

