### PR TITLE
Bug: 게임에서 유저상태 웹소켓 정상종료 되도록 수정

### DIFF
--- a/frontend/static/js/router/router.js
+++ b/frontend/static/js/router/router.js
@@ -135,7 +135,9 @@ export class Router {
         return;
       }
       const token = localStorage.getItem('2FA');
-      this.socket = new WebSocket(`ws://localhost:8000/ws/member/login_room/?token=${token}`);
+      if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
+        this.socket = new WebSocket(`ws://localhost:8000/ws/member/login_room/?token=${token}`);
+      }
 
       this.socket.onopen = function (event) {
         console.log('WebSocket connection opened.');


### PR DESCRIPTION
## #️⃣연관된 이슈

> #58 

## 📝작업 내용

> 게임 웹소켓에 있는 웹소켓 상태관련 조건문이 유저상태 웹소켓에는 없어 똑같이 적용하였음


### 스크린샷 (선택)

![스크린샷 2024-06-17 오후 7 09 14](https://github.com/BeyondPong/Frontend/assets/26542114/2783a69c-6635-4714-9f9a-30e6b83a90bf)
'remote 게임에서 게임 웹소켓 생성 이후, 메인페이지 링크 버튼으로 메인페이지 이동'
이 과정을 빠르게 반복했을 때 스크린샷에 나오는 에러 발생 (websocket is closed before the connection is established)

웹소켓 연결 상태 확인하는 조건 추가했습니다.
