### PR TITLE
Bug: 웹 소켓 에러해결

### DIFF
--- a/frontend/static/js/api/api.js
+++ b/frontend/static/js/api/api.js
@@ -166,7 +166,6 @@ export const deleteFriend = async (userId) => {
 };
 
 export const postTournamentNickName = async (nickName, roomName) => {
-  console.log("API " + roomName);
   try {
     const response = await fetch(`http://localhost:8000/play/${nickName}/`, {
       method: 'POST',
@@ -184,7 +183,7 @@ export const postTournamentNickName = async (nickName, roomName) => {
   } catch (error) {
     console.log(error);
   }
-}
+};
 
 export const postAddFriend = async (userId) => {
   try {

--- a/frontend/static/js/view/Play.js
+++ b/frontend/static/js/view/Play.js
@@ -130,8 +130,7 @@ export default class extends AbstractView {
       const data = await getProfileData();
       const nickname = data.nickname;
       WebSocketManager.connectGameSocket(`ws://localhost:8000/ws/play/${mode}/${roomName}/${nickname}/`);
-      const socket = WebSocketManager.returnGameSocket();
-      console.log(socket);
+      let socket = WebSocketManager.returnGameSocket();
 
       const loadingSpinner = document.getElementById('loading_spinner');
 
@@ -161,9 +160,13 @@ export default class extends AbstractView {
       socket.onclose = (event) => {
         console.log('Game socket closed');
       };
+
       socket.onerror = (event) => {
-        alert('Error occurred. Please try again.');
-        window.location.href = '/';
+        console.error('Game socket error:', event);
+        if (!WebSocketManager.isGameSocketConnecting) {
+          WebSocketManager.connectGameSocket(`ws://localhost:8000/ws/play/${mode}/${roomName}/${nickname}/`);
+          socket = WebSocketManager.returnGameSocket();
+        }
       };
 
       socket.onmessage = (event) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60

## 📝작업 내용

> 리모트 게임 매칭중 뒤로가기를 하고 빠르게 재접속 할 시, 소켓 에러가 나던 부분을 해결했습니다.
> 매칭 소켓이 에러가 발생 시 재연결 하는 로직 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 소켓이 연결중인지 판단하는 변수를 추가해서 소켓 중복연결을 방지했습니다.
> 소켓이 닫히기도 전에 재접속을 시도해서, 에러가 발생한 것 같습니다. 소켓 연결시도 보다 빠르게 파악하도록 내부에 isGameSocketConnect 변수를 만들어서 이를, 체크하고 재접속을 시도하는 로직을 추가했습니다.
> 추가로 gameSocketListener를 만들어서 해당 변수의 값을 true,false로 바꾸는 소켓 메소드를 추가했습니다!
> 확인해보시고 이해 안되시는 부분 있으면 질문주세요!