### PR TITLE
Feature: 토너먼트 대진표 UI 추가

### DIFF
--- a/frontend/static/css/play.css
+++ b/frontend/static/css/play.css
@@ -83,13 +83,6 @@
   box-shadow: 0px 0px 5px rgba(255, 255, 255, 0.5);
 }
 
-.tournament_number_flex {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
 .tournament_modal {
   width: auto;
   height: auto;
@@ -109,16 +102,183 @@
   color: var(--profile-color);
 }
 
-/* .tournament_number_text,
-.tournament_number {
-  color: var(--profile-color);
-  font-size: 1em;
-  font-weight: bold;
+.tournament_list {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
 }
 
-.tournament_number {
-  padding-bottom: 2rem;
-} */
+.tournament_player_box {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tournament_player {
+  width: 8vw;
+  height: 8vw;
+  --player-height: 8vw;
+  padding: 1.25rem;
+  margin: 0;
+  background-color: white;
+  border: 2px solid var(--profile-color);
+}
+
+.tournament_player_name {
+  background-color: var(--profile-background);
+  color: var(--black-color);
+  border-radius: 15px;
+  padding: 0.4rem;
+  text-align: center;
+}
+
+.tournament_left {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
+.tournament_right {
+  display: flex;
+  flex-direction: row;
+}
+
+.tournament_left_parent {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-left: 3.125rem;
+}
+
+.tournament_right_parent {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-right: 3.125rem;
+}
+
+.tournament_left_parent::after {
+  position: absolute;
+  content: '';
+  width: 1.5rem;
+  height: 0.125rem;
+  left: 0;
+  top: 45%;
+  background-color: white;
+  transform: translateX(-100%);
+}
+
+.tournament_right_parent::before {
+  content: '';
+  position: absolute;
+  background-color: white;
+  right: 0;
+  /* top: 45%; */
+  top: calc(var(--player-height) * 0.45);
+  transform: translateX(100%);
+  width: 1.5rem;
+  height: 0.125rem;
+}
+
+.tournament_right_parent::after {
+  position: absolute;
+  content: '';
+  width: 1.5rem;
+  height: 0.125rem;
+  left: 0;
+  top: 30%;
+  background-color: white;
+  transform: translateX(-100%);
+}
+
+/* childrens는 left, right 분리 안해도 될듯 */
+.tournament_left_childrens,
+.tournament_right_childrens {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3rem;
+}
+
+.tournament_left_child {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+  position: relative;
+}
+
+.tournament_left_child::before {
+  content: '';
+  position: absolute;
+  background-color: white;
+  right: 0;
+  top: 30%;
+  transform: translateX(100%);
+  width: 1.5rem;
+  height: 0.125rem;
+}
+
+.tournament_left_child::after {
+  content: '';
+  position: absolute;
+  background-color: white;
+  right: -1.5rem;
+  height: calc(50% + 4rem);
+  width: 0.125rem;
+  top: 30%;
+}
+
+.tournament_right_child {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+  position: relative;
+}
+
+.tournament_right_child::after {
+  content: '';
+  position: absolute;
+  background-color: white;
+  left: -1.5rem;
+  height: calc(50% + 4rem);
+  width: 0.125rem;
+  top: 30%;
+}
+
+.left_last_child::after {
+  content: '';
+  position: absolute;
+  background-color: white;
+  right: -1.5rem;
+  height: calc(50% + 4rem);
+  width: 0.125rem;
+  top: 30%;
+  transform: translateY(-100%);
+}
+
+.right_last_child::after {
+  content: '';
+  position: absolute;
+  background-color: white;
+  left: -1.5rem;
+  height: calc(50% + 4rem);
+  width: 0.125rem;
+  top: 30%;
+  transform: translateY(-100%);
+}
+
+.remove-before::before {
+  display: none;
+}
+
+.remove-after::after {
+  display: none;
+}
 
 @keyframes slideInFromRight {
   0% {

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -37,9 +37,66 @@
     padding-top: 2.6rem;
   }
 
+  /* tournament  */
+  .tournament_left_parent::after,
+  .tournament_right_parent::before,
+  .tournament_right_parent::after,
+  .tournament_left_child::before,
+  .tournament_left_child::after,
+  .tournament_right_child::after,
+  .left_last_child::after,
+  .right_last_child::after {
+    display: none;
+  }
+
+  .tournament_list {
+    flex-direction: column;
+  }
+
+  .tournament_player_box {
+    flex-direction: row;
+    border: 2px solid var(--profile-color);
+    box-sizing: border-box;
+    width: 30vw;
+    height: 10vw;
+    max-width: 32vw;
+    background-color: var(--profile-background);
+    overflow: hidden;
+    gap: 0;
+  }
+
+  .tournament_player {
+    width: 30%;
+    height: 100%;
+    padding: 0;
+  }
+
+  .tournament_player_name {
+    font-size: 0.9em;
+    border-radius: 0%;
+    align-content: center;
+  }
+
+  .tournament_right {
+    flex-direction: row-reverse;
+  }
+
+  .tournament_left_childrens,
+  .tournament_right_childrens {
+    gap: 0;
+  }
+
+  .tournament_left_parent,
+  .tournament_right_parent {
+    justify-content: center;
+    margin: 0;
+    margin-left: 2rem;
+  }
+
+  /* profile histroy table */
   .table_box {
     overflow-y: auto;
-    max-height: 12.5rem;
+    max-height: 20rem;
   }
 
   .table_box thead {

--- a/frontend/static/js/api/api.js
+++ b/frontend/static/js/api/api.js
@@ -165,15 +165,15 @@ export const deleteFriend = async (userId) => {
   }
 };
 
-export const postTournamentNickName = async (nickName, roomName) => {
+export const postTournamentNickName = async (nickName, realName, roomName) => {
   try {
-    const response = await fetch(`http://localhost:8000/play/${nickName}/`, {
+    const response = await fetch(`http://localhost:8000/play/nickname/`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer' + ' ' + localStorage.getItem('2FA'),
       },
-      body: JSON.stringify({ nickname: nickName, room_name: roomName }),
+      body: JSON.stringify({ nickname: nickName, realname: realName, room_name: roomName }),
     });
     if (!response.ok) {
       throw new Error(`HTTP error! Status: ${response.status}`);

--- a/frontend/static/js/view/Play.js
+++ b/frontend/static/js/view/Play.js
@@ -261,42 +261,127 @@ export default class extends AbstractView {
         container.removeChild(container.firstChild);
       }
       const newDiv = document.createElement('div');
-      newDiv.classList.add('history_container');
+      newDiv.classList.add('tournament_list');
       const tableHTML = `
-      <div class="table_box">
-        <table class="table_container">
-          <thead>
-            <tr>
-              <th>No.</th>
-              <th>${words[registry.lang].tournament_table_nickname}</th>
-              <th>${words[registry.lang].tournament_table_score}</th>
-            </tr>
-          </thead>
-          <tbody class="table_tbody">
-            <tr>
-              <td class="table_number">1</td>
-              <td class="table_nickname">아보카도</td>
-              <td class="table_score">11 Win 2 Lose</td>
-            </tr>
-            <tr>
-              <td class="table_number">2</td>
-              <td class="table_nickname">바나나</td>
-              <td class="table_score">1 Win 2 Lose</td>
-            </tr>
-            <tr>
-              <td class="table_number">3</td>
-              <td class="table_nickname">끄투마스터고승준</td>
-              <td class="table_score">0 Win 3 Lose</td>
-            </tr>
-            <tr>
-              <td class="table_number">4</td>
-              <td class="table_nickname">할라피뇨</td>
-              <td class="table_score">4 Win 0 Lose</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="tournament_left">
+          <div class="tournament_left_parent tournament_final">
+            <div class="tournament_player_box">
+              <div class="tournament_player">
+                final1
+              </div>
+            <div class="tournament_player_name">avocado</div>
+           </div>
+          </div>
+          <div class="tournament_left_childrens">
+            <div class="tournament_left_child">
+              <div class="tournament_left">
+                <div class="tournament_left_parent remove-after">
+                  <div class="tournament_player_box tournament_semi">
+                    <div class="tournament_player">
+                      semi1
+                    </div>
+                    <div class="tournament_player_name">seoson</div>
+                  </div>
+                </div> 
+              </div>
+            </div>
+            <div class="tournament_left_child left_last_child">
+              <div class="tournament_left">
+                <div class="tournament_left_parent remove-after">
+                  <div class="tournament_player_box tournament_semi">
+                    <div class="tournament_player">
+                      semi2
+                    </div>
+                    <div class="tournament_player_name">sgo</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="tournament_right">
+          <div class="tournament_right_parent remove-after">
+            <div class="tournament_player_box">
+              <div class="tournament_player remove-after">
+                final2
+              </div>
+              <div class="tournament_player_name">misukim</div>
+            </div>
+          </div>
+          <div class="tournament_right_childrens">
+            <div class="tournament_right_child">
+              <div class="tournament_right">
+                <div class="tournament_right_parent remove-before">
+                  <div class="tournament_player_box tournament_semi">
+                    <div class="tournament_player">
+                      semi1
+                    </div>
+                    <div class="tournament_player_name">johsn snow</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="tournament_right_child right_last_child">
+              <div class="tournament_right">
+                <div class="tournament_right_parent remove-before">
+                  <div class="tournament_player_box tournament_semi">
+                    <div class="tournament_player">
+                      semi2
+                    </div>
+                    <div class="tournament_player_name">jonim</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       `;
+
+      // const tableHTML = `
+      //   <div class="tournament_item">
+      //     <div class="tournament_item-parent">
+      //       <p>Parent</p>
+      //     </div>
+      //     <div class="tournament_item-childrens">
+      //       <div class="tournament_item-child">
+      //         <div class="tournament_item">
+      //           <div class="tournament_item-parent only-child-after">
+      //             <p>Parent2</p>
+      //             <div class="tournament_name">avocado</div>
+      //           </div>
+      //         </div>
+      //       </div>
+      //       <div class="tournament_item-child last-child">
+      //         <div class="tournament_item">
+      //           <div class="tournament_item-parent only-child-after">
+      //             <p>Parent3</p>
+      //           </div>
+      //         </div>
+      //       </div>
+      //     </div>
+      //   </div>
+      //   <div class="tournament_item2">
+      //     <div class="tournament_item2-parent only-child-after">
+      //       <p>Parent111</p>
+      //     </div>
+      //     <div class="tournament_item2-childrens">
+      //       <div class="tournament_item2-child">
+      //         <div class="tournament_item2">
+      //           <div class="tournament_item2-parent only-child-before">
+      //             <p>Parent222</p>
+      //           </div>
+      //         </div>
+      //       </div>
+      //       <div class="tournament_item2-child last-child2">
+      //         <div class="tournament_item2">
+      //           <div class="tournament_item2-parent only-child-before">
+      //             <p>Parent333</p>
+      //           </div>
+      //         </div>
+      //       </div>
+      //     </div>
+      //   </div>
+      // `;
       newDiv.innerHTML = tableHTML;
       container.replaceChildren(newDiv);
     });

--- a/frontend/static/js/view/Play.js
+++ b/frontend/static/js/view/Play.js
@@ -280,7 +280,7 @@ export default class extends AbstractView {
                     <div class="tournament_player">
                       semi1
                     </div>
-                    <div class="tournament_player_name">seoson</div>
+                    <div class="tournament_player_name">${checkNickName.nicknames[0].nickname}</div>
                   </div>
                 </div> 
               </div>
@@ -292,7 +292,7 @@ export default class extends AbstractView {
                     <div class="tournament_player">
                       semi2
                     </div>
-                    <div class="tournament_player_name">sgo</div>
+                    <div class="tournament_player_name">${checkNickName.nicknames[2] ? checkNickName.nicknames[2].nickname : ' '}</div>
                   </div>
                 </div>
               </div>
@@ -316,7 +316,7 @@ export default class extends AbstractView {
                     <div class="tournament_player">
                       semi1
                     </div>
-                    <div class="tournament_player_name">johsn snow</div>
+                    <div class="tournament_player_name">${checkNickName.nicknames[1] ? checkNickName.nicknames[1].nickname : ' '}</div>
                   </div>
                 </div>
               </div>
@@ -328,7 +328,7 @@ export default class extends AbstractView {
                     <div class="tournament_player">
                       semi2
                     </div>
-                    <div class="tournament_player_name">jonim</div>
+                    <div class="tournament_player_name">${checkNickName.nicknames[3] ? checkNickName.nicknames[3].nickname : ' '}</div>
                   </div>
                 </div>
               </div>
@@ -336,55 +336,10 @@ export default class extends AbstractView {
           </div>
         </div>
       `;
-
-      // const tableHTML = `
-      //   <div class="tournament_item">
-      //     <div class="tournament_item-parent">
-      //       <p>Parent</p>
-      //     </div>
-      //     <div class="tournament_item-childrens">
-      //       <div class="tournament_item-child">
-      //         <div class="tournament_item">
-      //           <div class="tournament_item-parent only-child-after">
-      //             <p>Parent2</p>
-      //             <div class="tournament_name">avocado</div>
-      //           </div>
-      //         </div>
-      //       </div>
-      //       <div class="tournament_item-child last-child">
-      //         <div class="tournament_item">
-      //           <div class="tournament_item-parent only-child-after">
-      //             <p>Parent3</p>
-      //           </div>
-      //         </div>
-      //       </div>
-      //     </div>
-      //   </div>
-      //   <div class="tournament_item2">
-      //     <div class="tournament_item2-parent only-child-after">
-      //       <p>Parent111</p>
-      //     </div>
-      //     <div class="tournament_item2-childrens">
-      //       <div class="tournament_item2-child">
-      //         <div class="tournament_item2">
-      //           <div class="tournament_item2-parent only-child-before">
-      //             <p>Parent222</p>
-      //           </div>
-      //         </div>
-      //       </div>
-      //       <div class="tournament_item2-child last-child2">
-      //         <div class="tournament_item2">
-      //           <div class="tournament_item2-parent only-child-before">
-      //             <p>Parent333</p>
-      //           </div>
-      //         </div>
-      //       </div>
-      //     </div>
-      //   </div>
-      // `;
       newDiv.innerHTML = tableHTML;
       container.replaceChildren(newDiv);
     });
+
   }
 
   tournamentModal() {

--- a/frontend/static/js/view/Profile.js
+++ b/frontend/static/js/view/Profile.js
@@ -26,16 +26,14 @@ export default class extends AbstractView {
               <nav>
               <a href="/" id="unregister" class="nav__link" data-link>${words[registry.lang].unregister}</a>
               <a href="/play" id="play_link" class="nav__link" data-link>${words[registry.lang].play}</a>
-              <a href="/profile" id="profile_link" class="nav__link" data-link style="pointer-events: none; color: grey; text-decoration: none;">${
-                words[registry.lang].profile
-              }</a>
+              <a href="/profile" id="profile_link" class="nav__link" data-link style="pointer-events: none; color: grey; text-decoration: none;">${words[registry.lang].profile
+      }</a>
               </nav>
               <section class="modal_container">
                 <div class="modal_content profile_modal">
                   <ul class="profile_nav">
-                    <li class="profile_nav_item"><a href="#" class="information">${
-                      words[registry.lang].information
-                    }</a></li>
+                    <li class="profile_nav_item"><a href="#" class="information">${words[registry.lang].information
+      }</a></li>
                     <li class="profile_nav_item"><a href="#" class="history">${words[registry.lang].history}</a></li>
                     <li class="profile_nav_item"><a href="#" class="friends">${words[registry.lang].friends}</a></li>
                     <li class="profile_nav_item"><a href="#" class="search">${words[registry.lang].search}</a></li>
@@ -100,22 +98,17 @@ export default class extends AbstractView {
         if (friend.status_msg === null) {
           friend.status_msg = `안녕하세요 ${friend.nickname}입니다.`;
         }
+        console.log(friend);
         const friendHTML = `
-            <div class="friend_state"></div>
+            <div class="friend_state ${friend.is_connected ? 'friend_online' : '#'}"></div>
             <div class="friend_image" style="background-image: url(/static/assets/${friend.profile_img}.png);"></div>
             <div class="friend_name">${friend.nickname}</div>
             <div class="friend_message">${friend.status_msg}</div>
-            <div class="friend_button delete_button"><button class="#" data-user-id=${friend.id}>${
-          words[registry.lang].friend_delete_button
-        }</button></div>
+            <div class="friend_button delete_button"><button class="#" data-user-id=${friend.id}>${words[registry.lang].friend_delete_button
+          }</button></div>
         `;
         friendDiv.innerHTML = friendHTML;
         friendResultBox.appendChild(friendDiv);
-        if (friend.is_connected === true) {
-          document.querySelector('.friend_state').classList.add('friend_online');
-        } else {
-          document.querySelector('.friend_state').classList.remove('friend_online');
-        }
       });
       const deleteButtons = Array.from(document.getElementsByClassName('delete_button'));
       deleteButtons.forEach((button) => {
@@ -168,13 +161,11 @@ export default class extends AbstractView {
           <div class="friend_message">${user.status_msg}</div>
         `;
         if (user.is_friend) {
-          resultHTML += `<div class="disabled_friend_button friend_add_button"><button class="add_button disabled_button" disabled data-user-id="${
-            user.id
-          }">${words[registry.lang].friend_add_button}</button></div>`;
+          resultHTML += `<div class="disabled_friend_button friend_add_button"><button class="add_button disabled_button" disabled data-user-id="${user.id
+            }">${words[registry.lang].friend_add_button}</button></div>`;
         } else {
-          resultHTML += `<div class="friend_button friend_add_button"><button class="add_button" data-user-id="${
-            user.id
-          }">${words[registry.lang].friend_add_button}</button></div>`;
+          resultHTML += `<div class="friend_button friend_add_button"><button class="add_button" data-user-id="${user.id
+            }">${words[registry.lang].friend_add_button}</button></div>`;
         }
         friendElement.innerHTML = resultHTML;
         searchResultBox.appendChild(friendElement);
@@ -244,9 +235,8 @@ export default class extends AbstractView {
               <button class="profile_status_save hidden" id="status_save"><i class="fa-solid fa-check"></i></button>
               </div>
             </div>
-            <span class="profile_count">${data.win_cnt}${words[registry.lang].win} ${data.lose_cnt}${
-          words[registry.lang].lose
-        } </span>
+            <span class="profile_count">${data.win_cnt}${words[registry.lang].win} ${data.lose_cnt}${words[registry.lang].lose
+          } </span>
           <section class="profile_img_modal hidden">
             <div class="profile_img_modal_flex">
               <div class="profile_img_set">
@@ -396,18 +386,16 @@ export default class extends AbstractView {
         <div class="form_container">
           <form action="#" class="form_box">
             <div class="input_container">
-              <input type="search" id="search_input" placeholder='${
-                words[registry.lang].friend_search_placeholder
-              }' required>
+              <input type="search" id="search_input" placeholder='${words[registry.lang].friend_search_placeholder
+        }' required>
             </div>
             <div class="search_button_container"><button type="button" class="search_button"><i class="fa-solid fa-magnifying-glass"></i></button></div>
           </form>
           <section class="friend_add_modal hidden" id="friend_add_modal">
             <div class="friend_add_modal_flex">
               <div><span class="friend_add_modal_message"><span></div>
-              <div><button class="save_button" id="friend_modal_button">${
-                words[registry.lang].confirm_button
-              }</button></div>
+              <div><button class="save_button" id="friend_modal_button">${words[registry.lang].confirm_button
+        }</button></div>
             </div>
           </section>
         </div>

--- a/frontend/static/js/view/Profile.js
+++ b/frontend/static/js/view/Profile.js
@@ -98,7 +98,6 @@ export default class extends AbstractView {
         if (friend.status_msg === null) {
           friend.status_msg = `안녕하세요 ${friend.nickname}입니다.`;
         }
-        console.log(friend);
         const friendHTML = `
             <div class="friend_state ${friend.is_connected ? 'friend_online' : '#'}"></div>
             <div class="friend_image" style="background-image: url(/static/assets/${friend.profile_img}.png);"></div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #68 

## 📝작업 내용

> 토너먼트 닉네임 중복검사 API의 수정된 것을 프론트에 반영했습니다. (realname 추가)

> 토너먼트 대진표를 ::before, ::after를 활용해 만들었고 반응형을 위해 2가지 버전으로 했습니다. 모바일용은 더 발전시킬 계획입니다.

> 닉네임 데이터를 받아서 넣은 상태이고 실시간으로 업데이트하는 건 추후 추가 예정

> 친구의 온/오프라인 상태가 잘 바뀌지 않아서 관련코드 수정했습니다.

### 스크린샷 (선택)

<img width="432" alt="스크린샷 2024-06-24 오후 1 43 57" src="https://github.com/BeyondPong/Frontend/assets/26542114/8a1f5c69-26d8-4a15-a1cc-094f242d21e5">
<img width="697" alt="스크린샷 2024-06-24 오후 1 44 11" src="https://github.com/BeyondPong/Frontend/assets/26542114/b177d81b-c61c-4041-a60a-14d30ee053e7">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
