### PR TITLE
Refactor: game_start를 한번만 보내도록 수정

### DIFF
--- a/frontend/static/js/game/remoteGame.js
+++ b/frontend/static/js/game/remoteGame.js
@@ -2,7 +2,7 @@ import { postGameResult } from '../api/api.js';
 import { addBlurBackground } from '../utility/blurBackGround.js';
 
 export const remoteGame = {
-  async init(socket, nickname, gameMode) {
+  async init(socket, nickname, gameMode, first_user) {
     addBlurBackground();
     const root = document.getElementById('app');
     while (root.childNodes.length > 0) {
@@ -130,12 +130,14 @@ export const remoteGame = {
     }
 
     function gameStart() {
-      const responseMessage = {
-        type: 'start_game',
-        width: $canvas.width,
-        height: $canvas.height,
-      };
-      socket.send(JSON.stringify(responseMessage));
+      if (nickname === first_user) {
+        const responseMessage = {
+          type: 'start_game',
+          width: $canvas.width,
+          height: $canvas.height,
+        };
+        socket.send(JSON.stringify(responseMessage));
+      }
     }
 
     function settingGame(data) {
@@ -204,7 +206,6 @@ export const remoteGame = {
       socket.onmessage = function (event) {
         const data = JSON.parse(event.data);
         if (data.type === 'game_start') {
-          console.log(data);
           settingGame(data.data);
         } else if (data.type == 'update_score') {
           gameStop();

--- a/frontend/static/js/view/Play.js
+++ b/frontend/static/js/view/Play.js
@@ -132,6 +132,7 @@ export default class extends AbstractView {
       const token = localStorage.getItem('2FA');
       WebSocketManager.connectGameSocket(`ws://localhost:8000/ws/play/${mode}/${roomName}/${nickname}/?token=${token}`);
       let socket = WebSocketManager.returnGameSocket();
+      let first_user;
 
       const loadingSpinner = document.getElementById('loading_spinner');
 
@@ -139,7 +140,7 @@ export default class extends AbstractView {
         console.log('ONLINE');
         removeBlurBackground();
         loadingSpinner.style.display = 'none';
-        this.remoteGame.init(socket, nickname, 'REMOTE');
+        this.remoteGame.init(socket, nickname, 'REMOTE', first_user);
       });
 
       window.addEventListener('offline', () => {
@@ -174,6 +175,7 @@ export default class extends AbstractView {
         const data = JSON.parse(event.data);
         loadingSpinner.style.display = 'none';
         if (data.type === 'start_game') {
+          first_user = data.data.first_user;
           const countdownContainer = document.querySelector('#countdown_container');
           countdownContainer.style.display = 'flex';
 
@@ -188,7 +190,7 @@ export default class extends AbstractView {
               countdownContainer.innerText = 'Go!';
               setTimeout(() => {
                 countdownContainer.style.display = 'none';
-                remoteGame.init(socket, nickname, 'REMOTE');
+                remoteGame.init(socket, nickname, 'REMOTE', first_user);
               }, 1000);
             }
           }, 1000);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60

## 📝작업 내용

> 백엔드와 협의 끝에 game_start메시지를 클라이언트 하나에서 보내도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> Play.js에서 nickname과 첫번째 유저를 비교해서 클라이언트 한쪽에서만 start_game 메시지를 보내도록 수정했습니다.
