### PR TITLE
Style: 2FA, 정책 버튼 및 모달 css 조정

### DIFF
--- a/frontend/static/css/2fa.css
+++ b/frontend/static/css/2fa.css
@@ -9,31 +9,43 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  margin: 0;
 }
 
 #lock_image {
   color: white;
-  font-size: 2rem;
+  font-size: calc(3vw + 3.5vh + 0.5vmin);
 }
 
 .modal_header {
   width: 100%;
   display: flex;
+  flex-direction: column;
   white-space: normal;
   word-break: break-all;
   align-items: center;
   justify-content: center;
   margin-bottom: 1rem;
-  gap: 0.5rem;
+  gap: 1rem;
+  color: var(--profile-color);
+  padding: 1rem;
 }
 
 .fa_modal h2 {
-  font-size: calc(2vw + 2vh);
+  /* font-size: calc(2vw + 2vh); */
+  font-size: calc(1.5vw + 1.5vh + 0.5vmin);
   color: var(--item-color);
   white-space: normal;
   word-break: break-all;
   display: inline;
   margin: 0;
+}
+
+.fa_modal h4 {
+  font-size: calc(0.5vw + 1vh + 0.5vmin);
+  font-weight: lighter;
 }
 
 .email_input {
@@ -43,35 +55,66 @@
   border: none;
   margin: 1% 0;
   padding: 1% 1%;
+  font-size: calc(0.7vw + 0.7vh + 0.5vmin);
 }
 
 .fa_code_input {
-  width: 7%;
-  height: 150%;
+  width: 58%;
+  height: 7vh;
   text-align: center;
-  font-size: 100%;
-  border-radius: 5px;
+  font-size: calc(1vw + 1vh + 0.5vmin);
+  border-radius: 7px;
   background-color: black;
   color: white;
 }
 
-.fa_modal button {
-  white-space: normal;
-  font-size: calc(1vw + 1vh + 0.5vmin);
-  width: 60%;
-  height: 2rem;
-  border-radius: 4px;
-  border: none;
-  color: var(--button-font-color);
-  background-color: var(--item-color);
-  font-size: calc(1vw + 1vh + 0.5vmin);
-  margin-top: 1rem;
+#checkBtn {
+  position: relative;
+  top: -6px;
+  border: 0;
+  transition: all 40ms linear;
+  border-radius: 5px;
+  margin-bottom: 0.625rem;
+  margin-left: 0.125rem;
+  margin-right: 0.125rem;
   word-break: break-all;
+  width: 60%;
+  height: 4vh;
+  white-space: normal;
+  margin-top: 1rem;
+  padding: 0.2rem 1rem;
+  font-size: calc(1vw + 0.5vh + 0.5vmin);
+  font-weight: bold;
+  border-radius: 5px;
+  overflow: hidden;
+  color: var(--black-color);
+  box-shadow:
+    0 0 0 2px #f2d413 inset,
+    0 0 0 2px rgba(255, 255, 255, 0.15) inset,
+    0 12px 0 0 #a98729,
+    0 8px 8px 10px rgba(5, 5, 5, 0.5);
+  background-color: var(--profile-background);
+  transition: filter 0.3s ease;
+}
+
+/* .fa_modal button:active:focus,
+.fa_modal button:focus:hover,
+.fa_modal button:focus {
+  outline: medium none;
+} */
+
+#checkBtn:active {
+  top: 2px;
+  color: var(--black-color);
+  box-shadow:
+    0 0 0 1px #c4b224 inset,
+    0 0 0 1px rgba(255, 255, 255, 0.15) inset,
+    0 1px 3px 1px rgba(0, 0, 0, 0.3);
+  background-color: var(--profile-background);
 }
 
 .fa_modal button:hover {
-  color: green;
-  background-color: antiquewhite;
+  filter: brightness(90%);
 }
 
 .fa_code_container {
@@ -79,34 +122,41 @@
   justify-content: center;
   gap: 1rem;
   margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 2rem;
 }
 
 .fa_code_input:focus {
   outline: none;
   border-color: var(--button-font-color);
 }
+
 #gdpr {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 80%;
-  height: auto;
-  background-color: white;
+  width: auto;
+  height: 80%;
+  background-color: rgba(0, 0, 0, 0.9);
   border-radius: 10px;
   z-index: 1000;
   display: grid;
   grid-template-rows: 0.2fr 0.2fr 0.2fr 0.1fr 0.3fr;
   gap: 0.5rem;
   font-size: calc(0.7vw + 0.8vh);
-  padding: 0.5rem;
+  padding: 2rem;
   box-sizing: border-box;
 }
 
+
 #gdpr h2 {
-  color: black;
+  color: var(--profile-color);
   text-align: center;
+}
+
+#gdpr_underline {
+  border-bottom: 2px solid var(--profile-color);
+  padding-bottom: 1rem;
 }
 
 #gdpr ul {
@@ -116,23 +166,34 @@
 }
 
 #gdpr ul li {
+  color: var(--profile-color);
+  font-style: italic;
   margin-bottom: 0.5rem;
 }
 
-#gdpr button {
-  width: 50%;
-  height: 100%;
-  background-color: #4caf50;
-  color: white;
+#gdpr p {
+  color: var(--profile-color);
+}
+
+#agreeBtn {
+  width: 60%;
+  height: 4vh;
   border: none;
+  background-color: var(--profile-color);
+  color: var(--black-color);
+  font-size: calc(1vw + 0.5vh + 0.5vmin);
+  font-weight: bold;
   border-radius: 5px;
   cursor: pointer;
   justify-self: center;
   margin: 0;
+  overflow: hidden;
+  transition: filter 0.3s ease;
 }
 
-#gdpr button:hover {
-  background-color: #45a049;
+#agreeBtn:hover {
+  /* filter: brightness(90%);
+  color: var(--button-font-color); */
 }
 
 #dropdown_2fa {

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -10,13 +10,13 @@
   }
 
   .fa_modal {
-    margin-left: 25%;
-    width: 50%;
+    width: 100%;
     height: 100%;
     background-color: rgba(18, 18, 18, 0.5);
     border-radius: 30px;
     grid-area: content;
     grid-column: 1;
+    padding: 1rem;
   }
 
   section {
@@ -35,6 +35,12 @@
   .history_container {
     position: relative;
     padding-top: 2.6rem;
+  }
+
+  #gdpr {
+    overflow-y: auto;
+    width: 80%;
+    max-height: 60vh;
   }
 
   /* tournament  */

--- a/frontend/static/js/view/2FA.js
+++ b/frontend/static/js/view/2FA.js
@@ -18,20 +18,17 @@ export default class extends AbstractView {
         Language
       </button>
       <ul id="d_menu" class="dropdown-menu drmenu" aria-labelledby="dropdownMenuButton">
-        <li><a id="item1" class="dropdown-item drmenu ${
-          currentLang === 'ko' ? 'disabled' : ''
-        }" href="/" data-lang="ko">ko</a></li>
-        <li><a id="item2" class="dropdown-item drmenu ${
-          currentLang === 'en' ? 'disabled' : ''
-        }" href="/" data-lang="en">en</a></li>
-        <li><a id="item3" class="dropdown-item drmenu ${
-          currentLang === 'jp' ? 'disabled' : ''
-        }" href="/" data-lang="jp">jp</a></li>
+        <li><a id="item1" class="dropdown-item drmenu ${currentLang === 'ko' ? 'disabled' : ''
+      }" href="/" data-lang="ko">ko</a></li>
+        <li><a id="item2" class="dropdown-item drmenu ${currentLang === 'en' ? 'disabled' : ''
+      }" href="/" data-lang="en">en</a></li>
+        <li><a id="item3" class="dropdown-item drmenu ${currentLang === 'jp' ? 'disabled' : ''
+      }" href="/" data-lang="jp">jp</a></li>
       </ul>
     </div>
     <div class="fa_modal">
       <div id="gdpr" style="display: none">
-        <h2>${words[currentLang].title}</h2>
+        <h2 id="gdpr_underline">${words[currentLang].title}</h2>
         <p>${words[currentLang].content}</p>
         <ul>
           <li><strong>${words[currentLang].items[0]}</strong></li>
@@ -42,12 +39,13 @@ export default class extends AbstractView {
           <li><strong>${words[currentLang].items[5]}</strong></li>
           <li><strong>${words[currentLang].items[6]}</strong></li>
         </ul>
-        <p>${words[currentLang].agreement}</p>
+        <p id="gdpr_underline">${words[currentLang].agreement}</p>
         <button id="agreeBtn">${words[currentLang].button}</button>
       </div>
       <div class="modal_header">
-      <i id="lock_image" class="fa-solid fa-lock"></i>
-      <h2>2FA</h2>
+        <i id="lock_image" class="fa-solid fa-lock"></i>
+        <h2>Two-Factor Authentication</h2>
+        <h4>Receive a temporary 6-digit login code via email</h4>
       </div>
       <input class="email_input" type="email"
             id="email"
@@ -61,7 +59,7 @@ export default class extends AbstractView {
         <input type="text" id="fa_code_5" maxlength="1" class="fa_code_input" required>
         <input type="text" id="fa_code_6" maxlength="1" class="fa_code_input" required>
       </div>
-      <button id="checkBtn">CHECK</button>
+      <button id="checkBtn">SEND CODE</button>
     </div>
     `;
     return modalHtml;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #84 

## 📝작업 내용

> 정책 모달이 넘치게 뜨는 것을 css로 조정했습니다. 버튼도 다른 버튼과 같도록 변경했습니다.
> 2FA 모달과 버튼을 다른 모달과 같은 느낌으로 조정했습니다.
> 위의 2개 모두 반응형 적용했습니다. 정책 모달은 내용이 많아 반응형 작동 시 스크롤 바가 생깁니다.

### 스크린샷 (선택)
![스크린샷 2024-06-26 오후 8 58 52](https://github.com/BeyondPong/Frontend/assets/26542114/36bbd35a-8e87-418b-a8cf-d4d9b5b0d95f)
<img width="377" alt="스크린샷 2024-06-26 오후 9 00 07" src="https://github.com/BeyondPong/Frontend/assets/26542114/11945164-c717-49cd-ad1c-066abb8ed83a">
![스크린샷 2024-06-26 오후 4 49 46](https://github.com/BeyondPong/Frontend/assets/26542114/f54ebbec-0d2a-4826-ba24-88c57aa58258)
![스크린샷 2024-06-26 오후 4 48 26](https://github.com/BeyondPong/Frontend/assets/26542114/2d6c8d7a-2a5f-4481-b1c8-b6f171a667be)
![스크린샷 2024-06-26 오후 8 58 22](https://github.com/BeyondPong/Frontend/assets/26542114/92f62738-3d3f-4362-ad9c-57dcf1951d51)

