### PR TITLE
Bug: 회원가입 직후 아바타 변경없이 저장 시 400 에러 수정

### DIFF
--- a/frontend/static/js/view/Profile.js
+++ b/frontend/static/js/view/Profile.js
@@ -19,16 +19,14 @@ export default class extends AbstractView {
               <nav>
               <a href="/" id="unregister" class="nav__link" data-link>${words[registry.lang].unregister}</a>
               <a href="/play" id="play_link" class="nav__link" data-link>${words[registry.lang].play}</a>
-              <a href="/profile" id="profile_link" class="nav__link" data-link style="pointer-events: none; color: grey; text-decoration: none;">${
-                words[registry.lang].profile
-              }</a>
+              <a href="/profile" id="profile_link" class="nav__link" data-link style="pointer-events: none; color: grey; text-decoration: none;">${words[registry.lang].profile
+      }</a>
               </nav>
               <section class="modal_container">
                 <div class="modal_content profile_modal">
                   <ul class="profile_nav">
-                    <li class="profile_nav_item"><a href="#" class="information">${
-                      words[registry.lang].information
-                    }</a></li>
+                    <li class="profile_nav_item"><a href="#" class="information">${words[registry.lang].information
+      }</a></li>
                     <li class="profile_nav_item"><a href="#" class="history">${words[registry.lang].history}</a></li>
                     <li class="profile_nav_item"><a href="#" class="friends">${words[registry.lang].friends}</a></li>
                     <li class="profile_nav_item"><a href="#" class="search">${words[registry.lang].search}</a></li>
@@ -98,9 +96,8 @@ export default class extends AbstractView {
             <div class="friend_image" style="background-image: url(/static/assets/${friend.profile_img}.png);"></div>
             <div class="friend_name">${friend.nickname}</div>
             <div class="friend_message">${friend.status_msg}</div>
-            <div class="friend_button delete_button"><button class="#" data-user-id=${friend.id}>${
-          words[registry.lang].friend_delete_button
-        }</button></div>
+            <div class="friend_button delete_button"><button class="#" data-user-id=${friend.id}>${words[registry.lang].friend_delete_button
+          }</button></div>
         `;
         friendDiv.innerHTML = friendHTML;
         friendResultBox.appendChild(friendDiv);
@@ -156,13 +153,11 @@ export default class extends AbstractView {
           <div class="friend_message">${user.status_msg}</div>
         `;
         if (user.is_friend) {
-          resultHTML += `<div class="disabled_friend_button friend_add_button"><button class="add_button disabled_button" disabled data-user-id="${
-            user.id
-          }">${words[registry.lang].friend_add_button}</button></div>`;
+          resultHTML += `<div class="disabled_friend_button friend_add_button"><button class="add_button disabled_button" disabled data-user-id="${user.id
+            }">${words[registry.lang].friend_add_button}</button></div>`;
         } else {
-          resultHTML += `<div class="friend_button friend_add_button"><button class="add_button" data-user-id="${
-            user.id
-          }">${words[registry.lang].friend_add_button}</button></div>`;
+          resultHTML += `<div class="friend_button friend_add_button"><button class="add_button" data-user-id="${user.id
+            }">${words[registry.lang].friend_add_button}</button></div>`;
         }
         friendElement.innerHTML = resultHTML;
         searchResultBox.appendChild(friendElement);
@@ -232,9 +227,8 @@ export default class extends AbstractView {
               <button class="profile_status_save hidden" id="status_save"><i class="fa-solid fa-check"></i></button>
               </div>
             </div>
-            <span class="profile_count">${data.win_cnt}${words[registry.lang].win} ${data.lose_cnt}${
-          words[registry.lang].lose
-        } </span>
+            <span class="profile_count">${data.win_cnt}${words[registry.lang].win} ${data.lose_cnt}${words[registry.lang].lose
+          } </span>
           <section class="profile_img_modal hidden">
             <div class="profile_img_modal_flex">
               <div class="profile_img_set">
@@ -287,6 +281,9 @@ export default class extends AbstractView {
               img.style.border = '4px solid var(--profile-background)';
               imgId = img.getAttribute('data-img-id');
             });
+            if (imgId === undefined) {
+              imgId = currentAvatarId;
+            }
             img.addEventListener('mouseenter', () => {
               img.style.transform = 'scale(1.1)';
             });
@@ -384,18 +381,16 @@ export default class extends AbstractView {
         <div class="form_container">
           <form action="#" class="form_box">
             <div class="input_container">
-              <input type="search" id="search_input" placeholder='${
-                words[registry.lang].friend_search_placeholder
-              }' required>
+              <input type="search" id="search_input" placeholder='${words[registry.lang].friend_search_placeholder
+        }' required>
             </div>
             <div class="search_button_container"><button type="button" class="search_button"><i class="fa-solid fa-magnifying-glass"></i></button></div>
           </form>
           <section class="friend_add_modal hidden" id="friend_add_modal">
             <div class="friend_add_modal_flex">
               <div><span class="friend_add_modal_message"><span></div>
-              <div><button class="save_button" id="friend_modal_button">${
-                words[registry.lang].confirm_button
-              }</button></div>
+              <div><button class="save_button" id="friend_modal_button">${words[registry.lang].confirm_button
+        }</button></div>
             </div>
           </section>
         </div>

--- a/frontend/static/js/view/Profile.js
+++ b/frontend/static/js/view/Profile.js
@@ -260,10 +260,18 @@ export default class extends AbstractView {
           avatarModal.classList.add('hidden');
         });
         imgSaveButton.addEventListener('click', async () => {
-          const imgData = await patchAvatar(imgId);
+          if (imgId === undefined) {
+            profileImage.style.backgroundImage = `url(/static/assets/${currentAvatarId}.png)`;
+            imgId = currentAvatarId;
+          } else if (currentAvatarId === imgId) {
+            profileImage.style.backgroundImage = `url(/static/assets/${imgId}.png)`;
+            currentAvatarId = imgId;
+          } else {
+            await patchAvatar(imgId);
+            profileImage.style.backgroundImage = `url(/static/assets/${imgId}.png)`;
+            currentAvatarId = imgId;
+          }
           avatarModal.classList.add('hidden');
-          profileImage.style.backgroundImage = `url(/static/assets/${imgId}.png)`;
-          currentAvatarId = imgId;
         });
 
         avatarEditButton.addEventListener('click', () => {
@@ -281,9 +289,6 @@ export default class extends AbstractView {
               img.style.border = '4px solid var(--profile-background)';
               imgId = img.getAttribute('data-img-id');
             });
-            if (imgId === undefined) {
-              imgId = currentAvatarId;
-            }
             img.addEventListener('mouseenter', () => {
               img.style.transform = 'scale(1.1)';
             });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93 

## 📝작업 내용

> 회원가입 직후, 아바타가 기본으로 되어있는데 이 상태에서 아바타 변경없이 저장 버튼을 누르면 아바타 변경 API에서 400 에러가 발생
> 아바타 변경 API에 보내는 변경된 아바타 id 변수가 기본 아바타 상태이고 선택되지 않았을 때 기본값이 할당되어 있지않아서 발생한 문제


![Screenshot 2024-06-26 at 8 56 55 PM](https://github.com/BeyondPong/Frontend/assets/26542114/5bd168a7-d707-4312-b858-5da1a0bd78f4)
![Screenshot 2024-06-26 at 8 58 07 PM](https://github.com/BeyondPong/Frontend/assets/26542114/499ee74a-a425-4012-888e-603dae8f96fc)
