### PR TITLE
Refactor: 로그인이 안되어 있을 시 프로필 페이지 비활성화 처리

### DIFF
--- a/frontend/static/js/view/Main.js
+++ b/frontend/static/js/view/Main.js
@@ -8,7 +8,7 @@ export default class extends AbstractView {
 
   async getHtml() {
     const currentLang = registry.lang;
-    const isLoggedIn = localStorage.getItem('token') !== null;
+    const isLogin = localStorage.getItem('token') !== null;
 
     return `
       <header class="main_header">
@@ -32,11 +32,13 @@ export default class extends AbstractView {
         </div>
       </header>
       <nav id="nav_links">
-        <a href="${isLoggedIn ? '/logout' : '/login'}" id="${
-      isLoggedIn ? 'logout_link' : 'login_link'
-    }" class="nav__link" data-link>${isLoggedIn ? words[currentLang].logout : words[currentLang].login}</a>
+        <a href="${isLogin ? '/logout' : '/login'}" id="${
+      isLogin ? 'logout_link' : 'login_link'
+    }" class="nav__link" data-link>${isLogin ? words[currentLang].logout : words[currentLang].login}</a>
         <a href="/play" id="play_link" class="nav__link" data-link>${words[currentLang].play}</a>
-        <a href="/profile" id="profile_link" class="nav__link" data-link>${words[currentLang].profile}</a>
+        <a href="/profile" id="profile_link" class="nav__link" style="${
+          isLogin ? '' : 'pointer-events: none; color: grey; text-decoration: none;'
+        }" data-link>${words[currentLang].profile}</a>
       </nav>
     `;
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #97

## 📝작업 내용

> 로그인이 안되어 있을 시, 메인의 프로필 버튼을 비활성화 처리했습니다. 

### 스크린샷 (선택)

<img width="989" alt="image" src="https://github.com/BeyondPong/Frontend/assets/84187086/e04435ea-2f84-412c-ab9e-d72d4b9aa181">

<img width="1024" alt="image" src="https://github.com/BeyondPong/Frontend/assets/84187086/78a3ff42-1802-4c39-b75d-5dd1ae8d7c98">



## 💬리뷰 요구사항(선택)

> isLogin변수의 상태에 따라 style을 넣었습니다.
