### PR TITLE
Bug: 친구추가 및 삭제 버튼 attribute 잘 받아오도록 수정

### DIFF
--- a/frontend/static/css/profile.css
+++ b/frontend/static/css/profile.css
@@ -362,7 +362,6 @@
   border-radius: 50%;
   border: 2px solid #fff;
   padding: 1rem;
-  /* background-image: url(https://cdn.intra.42.fr/users/22a150a2b718bb79bbe204dc8e4a4ae7/misukim.jpg); */
 }
 
 .friend_name {
@@ -377,12 +376,21 @@
 }
 
 .friend_button {
-  padding: 0.2rem 1rem;
+  width: 10%;
+}
+
+.friendButton {
+  width: 100%;
+  line-height: 2rem;
   background-color: var(--profile-background);
   border-radius: 5px;
   color: var(--black-color);
   cursor: pointer;
   font-weight: bold;
+}
+
+.friend_add_button {
+  width: 10%;
 }
 
 .disabled_button {
@@ -391,7 +399,6 @@
 }
 
 .disabled_friend_button {
-  padding: 0.2rem 1rem;
   border-radius: 5px;
   font-weight: bold;
   background-color: var(--disabled-button-background-color);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #115 

## 📝작업 내용

> 프로필에서 친구 삭제, 추가 버튼을 클릭했을 때 attribute를 받아오지 못하는 버그를 수정했습니다.

- 원인 1. div에 eventListener를 걸었고 attribute는 button에 있음
   - button에 eventListener 걸고 attribute는 button에 유지
 
- 원인 2. div와 button의 크기가 다름. div 안에 button이 중앙에 배치되어있어 div, button 둘 다 클릭할 수 있는 상황
  - div는 오직 크기 조절용으로 css 설정 조정, button에서 거의 모든 css 설정 조정. button의 width 100%로 button이 div를 덮게 만듦

추가로 tab 이동 및 엔터 이벤트도 다시 살펴봤습니다.

### 스크린샷 (선택)
<img width="1215" alt="스크린샷 2024-06-30 오후 9 30 29" src="https://github.com/BeyondPong/Frontend/assets/26542114/7b27e89a-525e-4afb-b4b7-74703c596994">
<img width="1197" alt="스크린샷 2024-06-30 오후 9 52 17" src="https://github.com/BeyondPong/Frontend/assets/26542114/98eb3cb4-fba7-4fbd-88e1-0291a8b93ed9">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

하나 고치면 하나 안돼서 git restore 4번 했는데 이게 맞나요
