### PR TITLE
Feature: 프로필 history에 텍스트 크기 조정 기능 추가

### DIFF
--- a/frontend/static/css/profile.css
+++ b/frontend/static/css/profile.css
@@ -258,6 +258,25 @@
 
 /* history */
 
+.text_size_buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.text_size {
+  color: var(--profile-color);
+}
+
+.text_size_button {
+  color: var(--profile-color);
+}
+
+.text_size_button:hover {
+  color: var(--black-color);
+}
+
 .table_container {
   table-layout: fixed;
   width: 100%;

--- a/frontend/static/css/responsive.css
+++ b/frontend/static/css/responsive.css
@@ -34,7 +34,7 @@
 
   .history_container {
     position: relative;
-    padding-top: 2.6rem;
+    /* padding-top: 2.6rem; */
   }
 
   #gdpr {
@@ -121,8 +121,8 @@
   }
 
   .table_box thead {
-    display: table;
-    position: absolute;
+    /* display: table; */
+    /* position: absolute; */
     top: 0;
     width: 100%;
   }

--- a/frontend/static/js/view/Profile.js
+++ b/frontend/static/js/view/Profile.js
@@ -19,16 +19,14 @@ export default class extends AbstractView {
               <nav>
               <a href="/" id="unregister" class="nav__link" data-link>${words[registry.lang].unregister}</a>
               <a href="/play" id="play_link" class="nav__link" data-link>${words[registry.lang].play}</a>
-              <a href="/profile" id="profile_link" class="nav__link" data-link style="pointer-events: none; color: grey; text-decoration: none;">${
-                words[registry.lang].profile
-              }</a>
+              <a href="/profile" id="profile_link" class="nav__link" data-link style="pointer-events: none; color: grey; text-decoration: none;">${words[registry.lang].profile
+      }</a>
               </nav>
               <section class="modal_container">
                 <div class="modal_content profile_modal">
                   <ul class="profile_nav">
-                    <li class="profile_nav_item"><a href="#" class="information">${
-                      words[registry.lang].information
-                    }</a></li>
+                    <li class="profile_nav_item"><a href="#" class="information">${words[registry.lang].information
+      }</a></li>
                     <li class="profile_nav_item"><a href="#" class="history">${words[registry.lang].history}</a></li>
                     <li class="profile_nav_item"><a href="#" class="friends">${words[registry.lang].friends}</a></li>
                     <li class="profile_nav_item"><a href="#" class="search">${words[registry.lang].search}</a></li>
@@ -78,6 +76,25 @@ export default class extends AbstractView {
         tr.innerHTML = historyHTML;
         tableBody.appendChild(tr);
       });
+      const initialFontSize = 1;
+      let containerFontSize = initialFontSize;
+      const tableContainer = document.querySelector('.table_container');
+      const reduceText = document.querySelector('.reduce');
+      const plusText = document.querySelector('.plus');
+      const percentageText = document.querySelector('.text_size');
+
+      reduceText.addEventListener('click', () => {
+        containerFontSize = Math.max(0.5, containerFontSize - 0.1);
+        tableContainer.style.fontSize = containerFontSize + 'rem';
+        const percentage = (containerFontSize / initialFontSize) * 100;
+        percentageText.textContent = `${percentage.toFixed(0)}%`;
+      });
+      plusText.addEventListener('click', () => {
+        containerFontSize = Math.min(2, containerFontSize + 0.1);
+        tableContainer.style.fontSize = containerFontSize + 'rem';
+        const percentage = (containerFontSize / initialFontSize) * 100;
+        percentageText.textContent = `${percentage.toFixed(0)}%`;
+      });
     }
   }
 
@@ -107,9 +124,8 @@ export default class extends AbstractView {
             <div class="friend_image" style="background-image: url(/static/assets/${friend.profile_img}.png);"></div>
             <div class="friend_name">${friend.nickname}</div>
             <div class="friend_message">${friend.status_msg}</div>
-            <div tabindex="0" class="friend_button"><button class="delete_button friendButton" data-user-id=${
-              friend.id
-            }>${words[registry.lang].friend_delete_button}</button></div>
+            <div tabindex="0" class="friend_button"><button class="delete_button friendButton" data-user-id=${friend.id
+          }>${words[registry.lang].friend_delete_button}</button></div>
         `;
         friendDiv.innerHTML = friendHTML;
         friendResultBox.appendChild(friendDiv);
@@ -202,13 +218,11 @@ export default class extends AbstractView {
           <div class="friend_message">${user.status_msg}</div>
         `;
         if (user.is_friend) {
-          resultHTML += `<div class="disabled_friend_button friend_add_button"><button class="add_button friendButton disabled_button" disabled data-user-id="${
-            user.id
-          }">${words[registry.lang].friend_add_button}</button></div>`;
+          resultHTML += `<div class="disabled_friend_button friend_add_button"><button class="add_button friendButton disabled_button" disabled data-user-id="${user.id
+            }">${words[registry.lang].friend_add_button}</button></div>`;
         } else {
-          resultHTML += `<div tabindex="0" class="friend_add_button"><button tabindex="0" class="add_button friendButton" data-user-id="${
-            user.id
-          }">${words[registry.lang].friend_add_button}</button></div>`;
+          resultHTML += `<div tabindex="0" class="friend_add_button"><button tabindex="0" class="add_button friendButton" data-user-id="${user.id
+            }">${words[registry.lang].friend_add_button}</button></div>`;
         }
         friendElement.innerHTML = resultHTML;
         searchResultBox.appendChild(friendElement);
@@ -323,9 +337,8 @@ export default class extends AbstractView {
               <div tabindex="0" class="profile_status_save hidden" id="status_save"><button><i class="fa-solid fa-check"></i></button></div>
               </div>
             </div>
-            <span class="profile_count">${data.win_cnt}${words[registry.lang].win} ${data.lose_cnt}${
-          words[registry.lang].lose
-        } </span>
+            <span class="profile_count">${data.win_cnt}${words[registry.lang].win} ${data.lose_cnt}${words[registry.lang].lose
+          } </span>
           <section class="profile_img_modal hidden">
             <div class="profile_img_modal_flex">
               <div class="profile_img_set">
@@ -335,12 +348,10 @@ export default class extends AbstractView {
                 <div tabindex="0" class="profile_img_select" data-img-id="4" style="background-image: url(/static/assets/4.png);"></div>
               </div>
               <div class="profile_img_buttons">
-                <div class="img_save_button" tabindex="0"><button class="save_button">${
-                  words[registry.lang].avatar_save_button
-                }</button></div>
-                <div class="img_close_button" tabindex="0"><button class="close_button">${
-                  words[registry.lang].avatar_close_button
-                }</button></div>
+                <div class="img_save_button" tabindex="0"><button class="save_button">${words[registry.lang].avatar_save_button
+          }</button></div>
+                <div class="img_close_button" tabindex="0"><button class="close_button">${words[registry.lang].avatar_close_button
+          }</button></div>
               </div>
             </div>
           </section>
@@ -528,6 +539,11 @@ export default class extends AbstractView {
       const container = document.createElement('div');
       container.classList.add('history_container');
       const historyHTML = `
+        <div class="text_size_buttons">
+          <div tabindex="0"><button class="text_size_button reduce"><i class="fa-solid fa-minus"></i></button></div>
+          <button class="text_size">100%</button>
+          <div tabindex="0"><button class="text_size_button plus"><i class="fa-solid fa-plus"></i></button></div>
+        </div>
         <div class="table_box">
           <table class="table_container">
             <thead>
@@ -565,18 +581,16 @@ export default class extends AbstractView {
         <div class="form_container">
           <form action="#" class="form_box">
             <div class="input_container">
-              <input type="search" id="search_input" placeholder='${
-                words[registry.lang].friend_search_placeholder
-              }' required>
+              <input type="search" id="search_input" placeholder='${words[registry.lang].friend_search_placeholder
+        }' required>
             </div>
             <div tabindex="0" class="search_button_container"><button type="button" class="search_button"><i class="fa-solid fa-magnifying-glass"></i></button></div>
           </form>
           <section class="friend_add_modal hidden" id="friend_add_modal">
             <div class="friend_add_modal_flex">
               <div><span class="friend_add_modal_message"><span></div>
-              <div class="save_button" id="friend_modal_button" tabindex="0"><button>${
-                words[registry.lang].confirm_button
-              }</button></div>
+              <div class="save_button" id="friend_modal_button" tabindex="0"><button>${words[registry.lang].confirm_button
+        }</button></div>
             </div>
           </section>
         </div>

--- a/frontend/static/js/view/Profile.js
+++ b/frontend/static/js/view/Profile.js
@@ -82,7 +82,19 @@ export default class extends AbstractView {
       const reduceText = document.querySelector('.reduce');
       const plusText = document.querySelector('.plus');
       const percentageText = document.querySelector('.text_size');
+      const reduceTextDiv = document.getElementById('reduceTextSize');
+      const plusTextDiv = document.getElementById('plusTextSize');
 
+      reduceTextDiv.addEventListener('keypress', (e) => {
+        if ((e.key === 'Enter' && reduceText) || e.key === 'click') {
+          reduceText.click();
+        }
+      });
+      plusTextDiv.addEventListener('keypress', (e) => {
+        if ((e.key === 'Enter' && plusText) || e.key === 'click') {
+          plusText.click();
+        }
+      })
       reduceText.addEventListener('click', () => {
         containerFontSize = Math.max(0.5, containerFontSize - 0.1);
         tableContainer.style.fontSize = containerFontSize + 'rem';
@@ -540,9 +552,9 @@ export default class extends AbstractView {
       container.classList.add('history_container');
       const historyHTML = `
         <div class="text_size_buttons">
-          <div tabindex="0"><button class="text_size_button reduce"><i class="fa-solid fa-minus"></i></button></div>
+          <div tabindex="0" id="reduceTextSize"><button class="text_size_button reduce"><i class="fa-solid fa-minus"></i></button></div>
           <button class="text_size">100%</button>
-          <div tabindex="0"><button class="text_size_button plus"><i class="fa-solid fa-plus"></i></button></div>
+          <div tabindex="0" id="plusTextSize"><button class="text_size_button plus"><i class="fa-solid fa-plus"></i></button></div>
         </div>
         <div class="table_box">
           <table class="table_container">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #118 

## 📝작업 내용

> 편의성 모듈을 위해 프로필의 history에만 텍스트 크기 조정 기능을 추가했습니다. 

### 스크린샷 (선택)
<img width="1001" alt="스크린샷 2024-07-01 오후 8 04 41" src="https://github.com/BeyondPong/Frontend/assets/26542114/52d083e7-dab9-45e7-bf9b-4334f1c38682">
<img width="1019" alt="스크린샷 2024-07-01 오후 8 04 50" src="https://github.com/BeyondPong/Frontend/assets/26542114/521d586f-b191-43d7-860f-87daca939f2d">

